### PR TITLE
Removing cowgrants.eth from being a child DAO

### DIFF
--- a/src/settings.json
+++ b/src/settings.json
@@ -31,9 +31,7 @@
   "private": false,
   "twitter": "CoWSwap",
   "website": "https://cow.fi/",
-  "children": [
-    "cowgrants.eth"
-  ],
+  "children": [],
   "coingecko": "cow-protocol",
   "categories": [
     "protocol"


### PR DESCRIPTION
In order to reduce confusion between CoW DAO proposals and CoW Grants proposals, it is suggested to remove cowgrants.eth from being a child of CoW DAO.