### PR TITLE
[DEMO — Do not merge] Use Split-Delegation Strategy from Gnosis Guild 

### DIFF
--- a/src/settings.json
+++ b/src/settings.json
@@ -40,6 +40,11 @@
     "0xa312c2ae6a06504cbebe89468e6f9dc01c8b23d4",
     "0xF44217A8b6b3f258BFFEaD635c226528aa516aea"
   ],
+  "delegationPortal": {
+    "delegationType": "split-delegation",
+    "delegationContract": "0xDE1e8A7E184Babd9F0E3af18f40634e9Ed6F0905",
+    "delegationApi": "https://delegate-api.gnosisguild.org"
+  },
   "strategies": [
     {
       "name": "split-delegation",

--- a/src/settings.json
+++ b/src/settings.json
@@ -34,9 +34,7 @@
   "website": "https://cow.fi/",
   "children": [],
   "coingecko": "cow-protocol",
-  "categories": [
-    "protocol"
-  ],
+  "categories": ["protocol"],
   "moderators": [
     "0x387fe763ddac7a6b568ee344fefc31f626bc837b",
     "0xa312c2ae6a06504cbebe89468e6f9dc01c8b23d4",
@@ -44,80 +42,50 @@
   ],
   "strategies": [
     {
-      "name": "erc20-balance-of",
+      "name": "split-delegation",
+      "network": "1",
       "params": {
-        "symbol": "vCOW (mainnet)",
-        "address": "0xd057b63f5e69cf1b929b356b579cba08d7688048",
-        "decimals": 18
-      },
-      "network": "1"
-    },
-    {
-      "name": "erc20-balance-of",
-      "params": {
-        "symbol": "vCOW (GC)",
-        "address": "0xc20C9C13E853fc64d054b73fF21d3636B2d97eaB",
-        "decimals": 18
-      },
-      "network": "100"
-    },
-    {
-      "name": "erc20-balance-of-delegation",
-      "params": {
-        "symbol": "Delegated vCOW (Mainnet)",
-        "address": "0xd057b63f5e69cf1b929b356b579cba08d7688048",
-        "decimals": 18,
-        "delegationSpace": "cow.eth"
-      },
-      "network": "1"
-    },
-    {
-      "name": "erc20-balance-of-delegation",
-      "params": {
-        "symbol": "Delegated vCOW (GC)",
-        "address": "0xc20C9C13E853fc64d054b73fF21d3636B2d97eaB",
-        "decimals": 18,
-        "delegationSpace": "cow.eth"
-      },
-      "network": "100"
-    },
-    {
-      "name": "erc20-balance-of",
-      "params": {
-        "symbol": "COW (Mainnet)",
-        "address": "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
-        "decimals": 18
-      },
-      "network": "1"
-    },
-    {
-      "name": "erc20-balance-of",
-      "params": {
-        "symbol": "COW (GC)",
-        "address": "0x177127622c4A00F3d409B75571e12cB3c8973d3c",
-        "decimals": 18
-      },
-      "network": "100"
-    },
-    {
-      "name": "erc20-balance-of-delegation",
-      "params": {
-        "symbol": "Delegate COW (Mainnet)",
-        "address": "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
-        "decimals": 18,
-        "delegationSpace": "cow.eth"
-      },
-      "network": "1"
-    },
-    {
-      "name": "erc20-balance-of-delegation",
-      "params": {
-        "symbol": "Delegate COW (GC)",
-        "address": "0x177127622c4A00F3d409B75571e12cB3c8973d3c",
-        "decimals": 18,
-        "delegationSpace": "cow.eth"
-      },
-      "network": "100"
+        "backendUrl": "https://delegate-api.gnosisguild.org",
+        "totalSupply": 1284949976,
+        "strategies": [
+          {
+            "name": "erc20-balance-of",
+            "params": {
+              "symbol": "vCOW (mainnet)",
+              "address": "0xd057b63f5e69cf1b929b356b579cba08d7688048",
+              "decimals": 18
+            },
+            "network": "1"
+          },
+          {
+            "name": "erc20-balance-of",
+            "params": {
+              "symbol": "vCOW (GC)",
+              "address": "0xc20C9C13E853fc64d054b73fF21d3636B2d97eaB",
+              "decimals": 18
+            },
+            "network": "100"
+          },
+          {
+            "name": "erc20-balance-of",
+            "params": {
+              "symbol": "COW (Mainnet)",
+              "address": "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
+              "decimals": 18
+            },
+            "network": "1"
+          },
+          {
+            "name": "erc20-balance-of",
+            "params": {
+              "symbol": "COW (GC)",
+              "address": "0x177127622c4A00F3d409B75571e12cB3c8973d3c",
+              "decimals": 18
+            },
+            "network": "100"
+          }
+        ]
+      }
     }
   ],
   "treasuries": [


### PR DESCRIPTION
# Description
This PR demonstrates the changes required to leverage the Split-Delegation system that we've built at Gnosis Guild. This system uses a new delegation contract, an indexing service, and an api for making and tracking delegations.

This new delegation system supports:
- split delegations (i can delegate 50% of my vote weight to someone and 50% to someone else)
- transitive delegations (i delegate to A, A delegates to B, my delegation flows to B)
- expiring delegations

All the code for the Split-Delegation system can be viewed here: https://github.com/gnosisguild/split-delegation

We've also made changes to the Snapshot frontend that allow this system to be used natively in the snapshot app, but are awaiting PR review. A demo of these changes can be viewed here: https://snapshot-ochre.vercel.app/#/cow.ggtest.eth/delegates

# Changes
In order to use this strategy, existing strategies used to get the voting scores should be moved to the `strategies` param on the Split-Delegation strategy. This makes them sub-strategies, and the split-delegation system will add up the scores from the sub-strategies and then will apply the vote weight calculations to compute the final voting power of any address.