### PR TITLE
Update settings.json to new oSnap plugin

### DIFF
--- a/src/settings.json
+++ b/src/settings.json
@@ -20,14 +20,7 @@
   "members": [],
   "network": "1",
   "plugins": {
-    "safeSnap": {
-      "safes": [
-        {
-          "network": "1",
-          "umaAddress": "0x85f520D59deBD4c2902BB7f79ACbc3Dd4b5AB699"
-        }
-      ]
-    }
+    "oSnap": {}
   },
   "private": false,
   "twitter": "CoWSwap",


### PR DESCRIPTION
# Description
Update settings.json to migrate from legacy safeSnap to new oSnap plugin

# Changes
oSnap docs include a [step by step guide](https://docs.uma.xyz/developers/osnap/osnap-proposal-verification) for doing this change though the Snapshot interface.

Unfortunately there's no explicit explanation for updating settings.json, so I had to reverse engineer it.
But the change is straight forward and the new oSnap plugin does not take any parameters. 

## How to test
1. Deploy a test space with the new settings
2. go to the space interface and check the settings
3. see the setup similar to how a successful setup looks like in the step by step guide on the oSnap docs
![image](https://github.com/user-attachments/assets/2849cd5b-0fb7-4515-95c9-6db1d1d1b7ac)

