### PR TITLE
Add new chains to DAO Snapshot Voting Strategies

### DIFF
--- a/src/settings.json
+++ b/src/settings.json
@@ -84,6 +84,15 @@
     {
       "name": "erc20-balance-of-with-delegation",
       "params": {
+        "symbol": "COW (Polygon)",
+        "address": "0x2F4efd3Aa42E15a1eC6114547151B63EE5D39958",
+        "decimals": 18
+      },
+      "network": "137"
+    },
+    {
+      "name": "erc20-balance-of-with-delegation",
+      "params": {
         "symbol": "COW (Base)",
         "address": "0xc694a91e6b071bF030A18BD3053A7fE09B6DaE69",
         "decimals": 18

--- a/src/settings.json
+++ b/src/settings.json
@@ -111,6 +111,44 @@
         "delegationSpace": "cow.eth"
       },
       "network": "100"
+    },
+    {
+      "name": "erc20-balance-of",
+      "params": {
+        "symbol": "COW (Arb)",
+        "address": "0xcb8b5CD20BdCaea9a010aC1F8d835824F5C87A04",
+        "decimals": 18
+      },
+      "network": "42161"
+    },
+    {
+      "name": "erc20-balance-of",
+      "params": {
+        "symbol": "COW (Base)",
+        "address": "0xc694a91e6b071bF030A18BD3053A7fE09B6DaE69",
+        "decimals": 18
+      },
+      "network": "8453"
+    },
+    {
+      "name": "erc20-balance-of-delegation",
+      "params": {
+        "symbol": "Delegate COW (Arb)",
+        "address": "0xcb8b5CD20BdCaea9a010aC1F8d835824F5C87A04",
+        "decimals": 18,
+        "delegationSpace": "cow.eth"
+      },
+      "network": "42161"
+    },
+    {
+      "name": "erc20-balance-of-delegation",
+      "params": {
+        "symbol": "Delegate COW (Base)",
+        "address": "0xc694a91e6b071bF030A18BD3053A7fE09B6DaE69",
+        "decimals": 18,
+        "delegationSpace": "cow.eth"
+      },
+      "network": "8453"
     }
   ],
   "treasuries": [

--- a/src/settings.json
+++ b/src/settings.json
@@ -37,7 +37,7 @@
   ],
   "strategies": [
     {
-      "name": "erc20-balance-of",
+      "name": "erc20-balance-of-with-delegation",
       "params": {
         "symbol": "vCOW (mainnet)",
         "address": "0xd057b63f5e69cf1b929b356b579cba08d7688048",
@@ -46,7 +46,7 @@
       "network": "1"
     },
     {
-      "name": "erc20-balance-of",
+      "name": "erc20-balance-of-with-delegation",
       "params": {
         "symbol": "vCOW (GC)",
         "address": "0xc20C9C13E853fc64d054b73fF21d3636B2d97eaB",
@@ -55,27 +55,7 @@
       "network": "100"
     },
     {
-      "name": "erc20-balance-of-delegation",
-      "params": {
-        "symbol": "Delegated vCOW (Mainnet)",
-        "address": "0xd057b63f5e69cf1b929b356b579cba08d7688048",
-        "decimals": 18,
-        "delegationSpace": "cow.eth"
-      },
-      "network": "1"
-    },
-    {
-      "name": "erc20-balance-of-delegation",
-      "params": {
-        "symbol": "Delegated vCOW (GC)",
-        "address": "0xc20C9C13E853fc64d054b73fF21d3636B2d97eaB",
-        "decimals": 18,
-        "delegationSpace": "cow.eth"
-      },
-      "network": "100"
-    },
-    {
-      "name": "erc20-balance-of",
+      "name": "erc20-balance-of-with-delegation",
       "params": {
         "symbol": "COW (Mainnet)",
         "address": "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
@@ -84,7 +64,7 @@
       "network": "1"
     },
     {
-      "name": "erc20-balance-of",
+      "name": "erc20-balance-of-with-delegation",
       "params": {
         "symbol": "COW (GC)",
         "address": "0x177127622c4A00F3d409B75571e12cB3c8973d3c",
@@ -93,27 +73,7 @@
       "network": "100"
     },
     {
-      "name": "erc20-balance-of-delegation",
-      "params": {
-        "symbol": "Delegate COW (Mainnet)",
-        "address": "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
-        "decimals": 18,
-        "delegationSpace": "cow.eth"
-      },
-      "network": "1"
-    },
-    {
-      "name": "erc20-balance-of-delegation",
-      "params": {
-        "symbol": "Delegate COW (GC)",
-        "address": "0x177127622c4A00F3d409B75571e12cB3c8973d3c",
-        "decimals": 18,
-        "delegationSpace": "cow.eth"
-      },
-      "network": "100"
-    },
-    {
-      "name": "erc20-balance-of",
+      "name": "erc20-balance-of-with-delegation",
       "params": {
         "symbol": "COW (Arb)",
         "address": "0xcb8b5CD20BdCaea9a010aC1F8d835824F5C87A04",
@@ -122,31 +82,11 @@
       "network": "42161"
     },
     {
-      "name": "erc20-balance-of",
+      "name": "erc20-balance-of-with-delegation",
       "params": {
         "symbol": "COW (Base)",
         "address": "0xc694a91e6b071bF030A18BD3053A7fE09B6DaE69",
         "decimals": 18
-      },
-      "network": "8453"
-    },
-    {
-      "name": "erc20-balance-of-delegation",
-      "params": {
-        "symbol": "Delegate COW (Arb)",
-        "address": "0xcb8b5CD20BdCaea9a010aC1F8d835824F5C87A04",
-        "decimals": 18,
-        "delegationSpace": "cow.eth"
-      },
-      "network": "42161"
-    },
-    {
-      "name": "erc20-balance-of-delegation",
-      "params": {
-        "symbol": "Delegate COW (Base)",
-        "address": "0xc694a91e6b071bF030A18BD3053A7fE09B6DaE69",
-        "decimals": 18,
-        "delegationSpace": "cow.eth"
       },
       "network": "8453"
     }


### PR DESCRIPTION
# Description
This PR includes the Base and Arb COW tokens on the snapshot voting strategies and refactors all the strategies' names to [erc20-balance-of-with-delegation](https://github.com/snapshot-labs/snapshot-strategies/tree/master/src/strategies/erc20-balance-of-with-delegation) to the strategy fits in the [max length (8)](https://docs.snapshot.box/user-guides/create#proposals-limitations).

# Changes
- Add the Arb and Base bridged COW tokens into the settings.
- Refactor all strategies to use `erc20-balance-of-with-delegation` to reduce total strategy length.


## How to test

1. Check that the `erc20-balance-with-delegation` returns the sum of the token balance and the delegations by using the [playground](https://testnet.v1.snapshot.box/#/playground/erc20-balance-of-with-delegation?query=eyJwYXJhbXMiOnsic3ltYm9sIjoiQ09XIChHQykiLCJhZGRyZXNzIjoiMHgxNzcxMjc2MjJjNEEwMEYzZDQwOUI3NTU3MWUxMmNCM2M4OTczZDNjIiwiZGVjaW1hbHMiOjE4fSwic3BhY2UiOiJjb3cuZXRoIiwibmV0d29yayI6IjEwMCIsInNuYXBzaG90IjoiMzgwMjM1NTMiLCJhZGRyZXNzZXMiOlsiMHgzZWJDODk1MzRkODRDYTUxOTg3QWY2MkVCQ2M3QjM1NkJGZDY1NzI4Il19).
2. Do the same for [arbitrum](https://testnet.v1.snapshot.box/#/playground/erc20-balance-of-with-delegation?query=eyJwYXJhbXMiOnsic3ltYm9sIjoiQ09XIChBcmIpIiwiYWRkcmVzcyI6IjB4Y2I4YjVDRDIwQmRDYWVhOWEwMTBhQzFGOGQ4MzU4MjRGNUM4N0EwNCIsImRlY2ltYWxzIjoxOH0sInNwYWNlIjoiY293LmV0aCIsIm5ldHdvcmsiOiI0MjE2MSIsInNuYXBzaG90IjoiMjk1MDUzNDQzIiwiYWRkcmVzc2VzIjpbIjB4MDBiM2VjMWRmYzc0ZjVFZDEzOEQ1MDlFNEI2RTc1NzQ2RWVkMEQ4MiJdfQ..) and [base](https://testnet.v1.snapshot.box/#/playground/erc20-balance-of-with-delegation?query=eyJwYXJhbXMiOnsic3ltYm9sIjoiQ09XIChCYXNlKSIsImFkZHJlc3MiOiIweGM2OTRhOTFlNmIwNzFiRjAzMEExOEJEMzA1M0E3ZkUwOUI2RGFFNjkiLCJkZWNpbWFscyI6MTh9LCJzcGFjZSI6IiIsIm5ldHdvcmsiOiI4NDUzIiwic25hcHNob3QiOiIyNDk5ODk1NCIsImFkZHJlc3NlcyI6WyIweDE1NWUwOTcxQTIzOTJjNDQ2YmUwMjM3M0E0RjRjOGRDNDI2NmYwMTUiXX0.) strategies.
3. Check this [testing space](https://testnet.snapshot.box/#/s-tn:cow-dao-test.eth/proposals) created with the new strategies. Note: on this space strategy we added a additional `delegationSpace` to sync with the main space delegations. This param by default is equal to the strategy space and that is why is not added on the PR.